### PR TITLE
Add a browser entry point

### DIFF
--- a/extension/extension-browser.ts
+++ b/extension/extension-browser.ts
@@ -1,0 +1,3 @@
+export function activate() {
+  /* NOP for browser */
+}

--- a/extension/toml.tmLanguage.json
+++ b/extension/toml.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-    "version": "v0.5.0",
+    "version": "v0.6.0",
     "scopeName": "source.toml",
     "uuid": "9b00c027-8f13-4f5a-a57e-d90478a1f817",
     "information_for_contributors": [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "engines": {
         "vscode": "^1.8.0"
     },
+    "main": "./dist/extension.js",
+    "browser": "./dist/extension-browser.js",
     "activationEvents": [
         "onLanguage:toml"
     ],
@@ -56,6 +58,8 @@
     },
     "devDependencies": {
         "@types/node": "^13.7.6",
+        "ts-node": "^10.4.0",
+        "typescript": "^4.4.4",
         "vscode": "^1.1.37"
     }
 }


### PR DESCRIPTION
This change adds a `browser` entry point to the extension -- currently, it is a NOP. The existing Node.JS entry point is kept.